### PR TITLE
Make discovery module public

### DIFF
--- a/src/discovery/data_types/mod.rs
+++ b/src/discovery/data_types/mod.rs
@@ -1,2 +1,2 @@
 pub(crate) mod spdp_participant_data;
-pub(crate) mod topic_data;
+pub mod topic_data;

--- a/src/discovery/mod.rs
+++ b/src/discovery/mod.rs
@@ -1,5 +1,5 @@
 pub(crate) mod content_filter_property;
-pub(crate) mod data_types;
+pub mod data_types;
 #[allow(clippy::module_inception)]
 pub(crate) mod discovery;
 pub(crate) mod discovery_db;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@
 mod serialization_test;
 #[macro_use]
 mod checked_impl;
-mod discovery;
+pub mod discovery;
 pub mod messages;
 mod network;
 pub mod structure;


### PR DESCRIPTION
Get the module of deserializing discovery data and get topic name/type in ddshark